### PR TITLE
don't lint iife files

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,2 @@
 test/nlmaps
-test/amaps.iife.js
+test/dist/amaps.iife.js


### PR DESCRIPTION
the amaps iife file is moved, so eslint should ignore the new file