### PR TITLE
Add placeholder to config and use updated nlmaps

### DIFF
--- a/config/amsterdam.config.js
+++ b/config/amsterdam.config.js
@@ -1,5 +1,5 @@
 export default {
-  version: 0.3,
+  version: 0.2,
   basemaps: {
     defaults: {
       attribution: 'Kaartgegevens CC-BY-4.0 Gemeente Amsterdam',

--- a/config/amsterdam.config.js
+++ b/config/amsterdam.config.js
@@ -48,7 +48,8 @@ export default {
   },
   geocoder: {
     suggestUrl: 'https://geodata.nationaalgeoregister.nl/locatieserver/v3/suggest?fq=gemeentenaam:amsterdam&fq=type:adres&',
-    lookupUrl: 'https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup?fq=gemeentenaam:amsterdam&fq=type:adres&'
+    lookupUrl: 'https://geodata.nationaalgeoregister.nl/locatieserver/v3/lookup?fq=gemeentenaam:amsterdam&fq=type:adres&',
+    placeholder: 'Kies adres...'
   },
   featureQuery: {
     baseUrl: 'https://api.data.amsterdam.nl/bag/nummeraanduiding/?format=json&locatie='
@@ -76,6 +77,5 @@ export default {
     geocoderResultList: ['embed-search__auto-suggest'],
     geocoderResultItem: ['embed-search__auto-suggest__item'],
     geocoderResultSelected: ['embed-search__auto-suggest__item--active']
-  },
-  placeholder: 'Kies adres...'
+  }
 };

--- a/config/amsterdam.config.js
+++ b/config/amsterdam.config.js
@@ -1,5 +1,5 @@
 export default {
-  version: 0.2,
+  version: 0.3,
   basemaps: {
     defaults: {
       attribution: 'Kaartgegevens CC-BY-4.0 Gemeente Amsterdam',
@@ -76,5 +76,6 @@ export default {
     geocoderResultList: ['embed-search__auto-suggest'],
     geocoderResultItem: ['embed-search__auto-suggest__item'],
     geocoderResultSelected: ['embed-search__auto-suggest__item--active']
-  }
+  },
+  placeholder: 'Kies adres...'
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amaps",
-  "version": "1.2.9",
+  "version": "1.2.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "amaps",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "browser": "dist/amaps.iife.js",
   "module": "dist/amaps.es.js",
-  "nlmaps_version": "2.3.41",
+  "nlmaps_version": "2.3.43",
   "directories": {
     "test": "test"
   },

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/index.js",
   "browser": "dist/amaps.iife.js",
   "module": "dist/amaps.es.js",
-  "nlmaps_version": "2.3.43",
+  "nlmaps_version": "2.3.45",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This branch uses the config version of nlmaps pr#89, allowing to add a placeholdertext